### PR TITLE
Fix combined plot rendering

### DIFF
--- a/app.R
+++ b/app.R
@@ -659,9 +659,8 @@ server <- function(input, output, session) {
            cex=1.2,col="red",adj=c(0.5,0.5))
     })
   },
-  height = 600,
-  width  = function() min(session$clientData$output_combined_plot_width, 1000)
-  )
+  height = 600)
+  outputOptions(output, "combined_plot", suspendWhenHidden = FALSE)
   
   
   output$downloadReport <- downloadHandler(


### PR DESCRIPTION
## Summary
- avoid width 0 for combined plot in shiny when hidden
- keep rendering even when tab is hidden

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684686e89d3483318887bb4a19a5efd0